### PR TITLE
Make is easier to change log directory and change log level for cas

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -50,5 +50,5 @@
 @goto:eof
 
 :run
-    call:package %1 %2 %3 & java -jar target/cas.war 
+    call:package %1 %2 %3 & java -jar target/cas.war
 @goto:eof

--- a/etc/cas/config/log4j2.xml
+++ b/etc/cas/config/log4j2.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- Specify the refresh internal in seconds. -->
 <Configuration monitorInterval="5" packages="org.apereo.cas.logging">
+    <Properties>
+        <!-- 
+        Default log directory is the current directory but that can be overridden with -Dcas.log.dir=<logdir>
+        Or you can change this property to a new default
+        -->
+        <Property name="cas.log.dir" >.</Property>
+        <Property name="cas.log.level" >warn</Property>
+    </Properties>
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
         </Console>
 
-        <RollingFile name="file" fileName="cas.log" append="true"
-                     filePattern="cas-%d{yyyy-MM-dd-HH}-%i.log">
+        <RollingFile name="file" fileName="${sys:cas.log.dir}/cas.log" append="true"
+                     filePattern="${sys:cas.log.dir}/cas-%d{yyyy-MM-dd-HH}-%i.log">
             <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />
@@ -15,8 +23,8 @@
                 <TimeBasedTriggeringPolicy />
             </Policies>
         </RollingFile>
-        <RollingFile name="auditlogfile" fileName="cas_audit.log" append="true"
-                     filePattern="cas_audit-%d{yyyy-MM-dd-HH}-%i.log">
+        <RollingFile name="auditlogfile" fileName="${sys:cas.log.dir}/cas_audit.log" append="true"
+                     filePattern="${sys:cas.log.dir}/cas_audit-%d{yyyy-MM-dd-HH}-%i.log">
             <PatternLayout pattern="%d %p [%c] - %m%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />
@@ -25,8 +33,8 @@
             </Policies>
         </RollingFile>
 
-        <RollingFile name="perfFileAppender" fileName="perfStats.log" append="true"
-                     filePattern="perfStats-%d{yyyy-MM-dd-HH}-%i.log">
+        <RollingFile name="perfFileAppender" fileName="${sys:cas.log.dir}/perfStats.log" append="true"
+                     filePattern="${sys:cas.log.dir}/perfStats-%d{yyyy-MM-dd-HH}-%i.log">
             <PatternLayout pattern="%m%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />
@@ -53,11 +61,11 @@
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
-        <AsyncLogger name="org.apereo" level="warn" additivity="false" includeLocation="true">
+        <AsyncLogger name="org.apereo" level="${sys:cas.log.level}" additivity="false" includeLocation="true">
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
-        <AsyncLogger name="org.apereo.services.persondir" level="warn" additivity="false" includeLocation="true">
+        <AsyncLogger name="org.apereo.services.persondir" level="${sys:cas.log.level}" additivity="false" includeLocation="true">
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
@@ -100,7 +108,7 @@
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
-        <AsyncLogger name="org.springframework.amqp" level="off" additivity="false">
+        <AsyncLogger name="org.springframework.amqp" level="error" additivity="false">
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
@@ -160,8 +168,8 @@
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
-        <AsyncLogger name="org.springframework.context.annotation" level="off" additivity="false" />
-        <AsyncLogger name="org.springframework.boot.devtools" level="off" additivity="false" />
+        <AsyncLogger name="org.springframework.context.annotation" level="error" />
+        <AsyncLogger name="org.springframework.boot.devtools" level="error" />
         <AsyncLogger name="org.jasig.spring" level="warn" additivity="false">
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
@@ -171,7 +179,7 @@
             <AppenderRef ref="casFile"/>
         </AsyncLogger>
 
-        <AsyncLogger name="org.apache.http" level="off" additivity="false">
+        <AsyncLogger name="org.apache.http" level="error" additivity="false">
             <AppenderRef ref="casConsole"/>
             <AppenderRef ref="casFile"/>
         </AsyncLogger>


### PR DESCRIPTION
I added some properties for the log directory so its easier to change the location of the logs from the current directory (which doesn't work well if someone is dropping war in tomcat). Log4j2 will look for cas.log.dir system property and use it but it will fall back to the property in the file, which is easier to change in one place. 

I also changed things that were "off" to "error" and made two Loggers that had logging and additivity off to just be at error level (so errors would go to the console at least). 

I didn't make this change but I feel like the root logger should be at warn and if you want to turn off warnings then it should be done explicitly for specific things. Off should probably never be used without a comment as to why errors are being turned off. 

I think additivity could be used to make this file more compact if it were only used when the root loggers of casConsole and casFile weren't desired (e.g. audit and perf logs, or if you want webflow logging in file but not console).  Most loggers should inherit appenders from root. 
