### PR TITLE
Use additivity to get close to same results with less verbosity.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -46,7 +46,7 @@
 @goto:eof
 
 :debug
-    call:package %1 %2 %3 & java -Xdebug -Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n -jar target/cas.war 
+    call:package %1 %2 %3 & java -Xdebug -Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n -jar target/cas.war
 @goto:eof
 
 :run

--- a/etc/cas/config/log4j2.xml
+++ b/etc/cas/config/log4j2.xml
@@ -7,13 +7,13 @@
         Or you can change this property to a new default
         -->
         <Property name="cas.log.dir" >.</Property>
+        <!-- To see more CAS specific logging, adjust this property to info or debug or run server with -Dcas.log.leve=debug -->
         <Property name="cas.log.level" >warn</Property>
     </Properties>
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
         </Console>
-
         <RollingFile name="file" fileName="${sys:cas.log.dir}/cas.log" append="true"
                      filePattern="${sys:cas.log.dir}/cas-%d{yyyy-MM-dd-HH}-%i.log">
             <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
@@ -57,143 +57,60 @@
         </CasAppender>
     </Appenders>
     <Loggers>
-        <AsyncLogger name="com.couchbase" level="warn" additivity="false" includeLocation="true">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.apereo" level="${sys:cas.log.level}" additivity="false" includeLocation="true">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.apereo.services.persondir" level="${sys:cas.log.level}" additivity="false" includeLocation="true">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.apache" level="error" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.cloud.server" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.cloud.client" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.cloud.bus" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.aop" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.boot" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.boot.actuate.autoconfigure" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.webflow" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.session" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.amqp" level="error" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.integration" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.messaging" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.web" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.orm.jpa" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.scheduling" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.thymeleaf" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.pac4j" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.opensaml" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="net.sf.ehcache" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="com.ryantenney.metrics" level="warn" additivity="false">
-            <AppenderRef ref="console"/>
-            <AppenderRef ref="file"/>
-        </AsyncLogger>
-        <AsyncLogger name="net.jradius" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.openid4java" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.ldaptive" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="com.hazelcast" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
+        <!-- If adding a Logger with level set higher than warn, make category as selective as possible -->
+        <!-- Loggers inherit appenders from Root Logger unless additivity is false -->
+        <AsyncLogger name="org.apereo" level="${sys:cas.log.level}" includeLocation="true"/>
+        <AsyncLogger name="org.apereo.services.persondir" level="${sys:cas.log.level}" includeLocation="true"/>
+        <AsyncLogger name="org.apereo.cas.web.flow" level="info" includeLocation="true"/>
+        <AsyncLogger name="org.apache" level="warn" />
+        <AsyncLogger name="org.apache.http" level="error" />
+        <AsyncLogger name="org.springframework" level="warn" />
+        <AsyncLogger name="org.springframework.cloud.server" level="warn" />
+        <AsyncLogger name="org.springframework.cloud.client" level="warn" />
+        <AsyncLogger name="org.springframework.cloud.bus" level="warn" />
+        <AsyncLogger name="org.springframework.aop" level="warn" />
+        <AsyncLogger name="org.springframework.boot" level="warn" />
+        <AsyncLogger name="org.springframework.boot.actuate.autoconfigure" level="warn" />
+        <AsyncLogger name="org.springframework.webflow" level="warn" />
+        <AsyncLogger name="org.springframework.session" level="warn" />
+        <AsyncLogger name="org.springframework.amqp" level="error" />
+        <AsyncLogger name="org.springframework.integration" level="warn" />
+        <AsyncLogger name="org.springframework.messaging" level="warn" />
+        <AsyncLogger name="org.springframework.web" level="warn" />
+        <AsyncLogger name="org.springframework.orm.jpa" level="warn" />
+        <AsyncLogger name="org.springframework.scheduling" level="warn" />
         <AsyncLogger name="org.springframework.context.annotation" level="error" />
         <AsyncLogger name="org.springframework.boot.devtools" level="error" />
-        <AsyncLogger name="org.jasig.spring" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.springframework.web.socket" level="warn" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
+        <AsyncLogger name="org.springframework.web.socket" level="warn" />
+        <AsyncLogger name="org.thymeleaf" level="warn" />
+        <AsyncLogger name="org.pac4j" level="warn" />
+        <AsyncLogger name="org.opensaml" level="warn"/>
+        <AsyncLogger name="net.sf.ehcache" level="warn" />
+        <AsyncLogger name="com.couchbase" level="warn" includeLocation="true"/>
+        <AsyncLogger name="com.ryantenney.metrics" level="warn" />
+        <AsyncLogger name="net.jradius" level="warn" />
+        <AsyncLogger name="org.openid4java" level="warn" />
+        <AsyncLogger name="org.ldaptive" level="warn" />
+        <AsyncLogger name="com.hazelcast" level="warn" />
+        <AsyncLogger name="org.jasig.spring" level="warn" />
 
-        <AsyncLogger name="org.apache.http" level="error" additivity="false">
-            <AppenderRef ref="casConsole"/>
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
+        <!-- Log perf stats only to perfStats.log -->
         <AsyncLogger name="perfStatsLogger" level="info" additivity="false" includeLocation="true">
             <AppenderRef ref="casPerf"/>
         </AsyncLogger>
-        <AsyncLogger name="org.apereo.cas.web.flow" level="info" additivity="true" includeLocation="true">
-            <AppenderRef ref="casFile"/>
-        </AsyncLogger>
-        <AsyncLogger name="org.apereo.inspektr.audit.support" level="info" includeLocation="true">
+
+        <!-- Log audit to all root appenders, and also to audit log (additivity is not false) -->
+        <AsyncLogger name="org.apereo.inspektr.audit.support" level="info" includeLocation="true" >
             <AppenderRef ref="casAudit"/>
-            <AppenderRef ref="casFile"/>
         </AsyncLogger>
-        <AsyncRoot level="error">
+
+        <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->
+        <AsyncRoot level="warn">
+            <AppenderRef ref="casFile"/>
+            <!-- 
+                 For deployment to an application server running as service, 
+                 delete the casConsole appender below
+            -->
             <AppenderRef ref="casConsole"/>
         </AsyncRoot>
     </Loggers>


### PR DESCRIPTION
This also makes it easier to turn off console logging by only defining it in the root appender.

There are some differences, like I set org.apache level to warn instead of error, lots of things live under org.apache and it would be better to adjust them individually rather than turn off warn messages for all of them.

