### PR TITLE
Add gencert argument to build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,9 +1,13 @@
 @echo off
 
+set CAS_DIR=\etc\cas
+set CONFIG_DIR=\etc\cas\config
+set DNAME="CN = cas.example.org OU = Example OU = Org  C = US"
+
 @rem Check for mvn in path, use it if found, otherwise use maven wrapper
 @set MAVEN_CMD=mvn
-@WHERE /Q mvn
-@IF %ERRORLEVEL% NEQ 0 set MAVEN_CMD=.\mvnw.bat
+@where /q mvn
+@if %ERRORLEVEL% neq 0 set MAVEN_CMD=.\mvnw.bat
 
 @if "%1" == "" call:help
 @if "%1" == "copy" call:copy
@@ -13,12 +17,12 @@
 @if "%1" == "debug" call:debug %2 %3 %4
 @if "%1" == "run" call:run %2 %3 %4
 @if "%1" == "help" call:help
+@if "%1" == "gencert" call:gencert
 
 @rem function section starts here
 @goto:eof
 
 :copy
-    set CONFIG_DIR=\etc\cas\config
     @echo "Creating configuration directory under %CONFIG_DIR%"
     if not exist %CONFIG_DIR% mkdir %CONFIG_DIR%
 
@@ -27,7 +31,9 @@
 @goto:eof
 
 :help
-    @echo "Usage: build.bat [copy|clean|package|run|debug|bootrun] [optional extra args for maven]"
+    @echo "Usage: build.bat [copy|clean|package|run|debug|bootrun|gencert] [optional extra args for maven]"
+    @echo "To get started on a clean system, run "build.bat copy" and "build.bat gencert", then "build.bat run"
+    @echo "Note that using the copy or gencert arguments will create and/or overwrite the %CAS_DIR% which is outside this project"
 @goto:eof
 
 :clean
@@ -51,4 +57,16 @@
 
 :run
     call:package %1 %2 %3 & java -jar target/cas.war
+@goto:eof
+
+:gencert
+    where /q keytool
+    if ERRORLEVEL 1 (
+        @echo Java keytool.exe not found in path. 
+        exit /B
+    ) else (
+        if not exist %CAS_DIR% mkdir %CAS_DIR%
+        echo Generating self-signed SSL cert for %DNAME% in %CAS_DIR%\thekeystore
+        keytool -genkeypair -alias cas -keyalg RSA -keypass changeit -storepass changeit -keystore %CAS_DIR%\thekeystore -dname %DNAME%
+    )
 @goto:eof


### PR DESCRIPTION
This adds an option to build.cmd that will generate a self-signed cert in "thekeystore" so someone can get up and running by checking out overlay and typing:

build help
build copy
build gencert
build run

The build help is not necessary but it includes a warning about how copy and gencert will create folders outside of project directory. 