### PR TITLE
Update for 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generic CAS WAR overlay to exercise the latest versions of CAS. This overlay cou
 # Versions
 
 ```xml
-<cas.version>5.0.x</cas.version>
+<cas.version>5.1.x</cas.version>
 ```
 
 # Requirements
@@ -66,7 +66,23 @@ Run the CAS web application as an executable WAR via Spring Boot. This is most u
 
 Be careful with this method of deployment. `bootRun` is not designed to work with already executable WAR artifacts such that CAS server web application. YMMV. Today, uses of this mode ONLY work when there is **NO OTHER** dependency added to the build script and the `cas-server-webapp` is the only present module. See [this issue](https://github.com/apereo/cas/issues/2334) and [this issue](https://github.com/spring-projects/spring-boot/issues/8320) for more info.
 
+
+## Spring Boot App Server Selection
+There is an app.server property in the pom.xml that can be used to select a spring boot application server.
+It defaults to "-tomcat" but "-jetty" and "-undertow" are supported. 
+It can also be set to an empty value (nothing) if you want to deploy CAS to an external application server of your choice and you don't want the spring boot libraries included. 
+
+```xml
+<app.server>-tomcat<app.server>
+```
+
+## Windows Build
+If you are building on windows, try build.cmd instead of build.sh. Arguments are similar but for usage, run:  
+
+```
+build.cmd help
+```
+
 ## External
 
 Deploy resultant `target/cas.war`  to a servlet container of choice.
-

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,13 @@
                     <recompressZippedFiles>false</recompressZippedFiles>
                     <archive>
                         <compress>false</compress>
-                        <manifestFile>${project.build.directory}/war/work/org.apereo.cas/cas-server-webapp/META-INF/MANIFEST.MF
+                        <manifestFile>${project.build.directory}/war/work/org.apereo.cas/cas-server-webapp${app.server}/META-INF/MANIFEST.MF
                         </manifestFile>
                     </archive>
                     <overlays>
                         <overlay>
                             <groupId>org.apereo.cas</groupId>
-                            <artifactId>cas-server-webapp</artifactId>
+                            <artifactId>cas-server-webapp${app.server}</artifactId>
                         </overlay>
                     </overlays>
                 </configuration>
@@ -61,7 +61,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apereo.cas</groupId>
-            <artifactId>cas-server-webapp</artifactId>
+            <artifactId>cas-server-webapp${app.server}</artifactId>
             <version>${cas.version}</version>
             <type>war</type>
             <scope>runtime</scope>
@@ -69,8 +69,10 @@
     </dependencies>
 
     <properties>
-        <cas.version>5.0.6</cas.version>
-        <springboot.version>1.4.2.RELEASE</springboot.version>
+        <cas.version>5.1.0</cas.version>
+        <springboot.version>1.5.3.RELEASE</springboot.version>
+        <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
+        <app.server>-tomcat</app.server> 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
You may already have something else in the works, but this is what I had to do to the pom to get it to work.  I added app.server variable and tried it out with it set to -tomcat and -jetty. I don't like having the property include the dash but if you want to use the overlay to build a war without spring boot then you want it blank. The variable could be the whole artifactId and it could be set in maven profiles to allow switching without modifying pom. 