### PR TITLE
Add command shell to overlay

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -25,6 +25,7 @@
 @if "%1" == "run" call:run %2 %3 %4
 @if "%1" == "help" call:help
 @if "%1" == "gencert" call:gencert
+@if "%1" == "command" call:command
 
 @rem function section starts here
 @goto:eof
@@ -38,7 +39,7 @@
 @goto:eof
 
 :help
-    @echo "Usage: build.bat [copy|clean|package|run|debug|bootrun|gencert] [optional extra args for maven]"
+    @echo "Usage: build.bat [copy|clean|package|run|debug|bootrun|gencert|command] [optional extra args for maven]"
     @echo "To get started on a clean system, run "build.bat copy" and "build.bat gencert", then "build.bat run"
     @echo "Note that using the copy or gencert arguments will create and/or overwrite the %CAS_DIR% which is outside this project"
 @goto:eof
@@ -79,4 +80,12 @@
         @echo Exporting cert for use in trust store (used by cas clients)
         keytool -exportcert -alias cas -storepass changeit -keystore %CAS_DIR%\thekeystore -file %CAS_DIR%\cas.cer
     )
+@goto:eof
+
+:command
+    for /f %%i in ('call %MAVEN_CMD% -q --non-recursive "-Dexec.executable=cmd" "-Dexec.args=/C echo ${cas.version}" "org.codehaus.mojo:exec-maven-plugin:1.3.1:exec"') do set CAS_VERSION=%%i
+    @set CAS_VERSION=%CAS_VERSION: =%
+    @set COMMAND_FILE=target\cas-server-support-shell-%CAS_VERSION%.jar
+     if not exist %COMMAND_FILE% powershell.exe -Command (new-object System.Net.WebClient).DownloadFile('http://repo1.maven.org/maven2/org/apereo/cas/cas-server-support-shell/%CAS_VERSION%/cas-server-support-shell-%CAS_VERSION%.jar','%COMMAND_FILE%')
+     call java %JAVA_ARGS% -jar %COMMAND_FILE% %1 %2 %3
 @goto:eof

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,13 @@ function gencert() {
 }
 
 function command() {
-	package && java -jar target/cas/WEB-INF/lib/cas-server-support-shell-*.jar "$@"
+        CAS_VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${cas.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec 2>/dev/null)
+        COMMAND_FILE="./target/cas-server-support-shell-${CAS_VERSION}.jar"
+        if [ ! -f "$COMMAND_FILE" ]; then
+            package
+            wget -q http://repo1.maven.org/maven2/org/apereo/cas/cas-server-support-shell/${CAS_VERSION}/cas-server-support-shell-${CAS_VERSION}.jar -P ./target
+        fi
+        java -jar target/cas-server-support-shell-${CAS_VERSION}.jar "$@"
 }
 
 if [ $# -eq 0 ]; then

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ function help() {
 	echo "	debug: Run CAS.war and listen for Java debugger on port 5000"
 	echo "	bootrun: Run with maven spring boot plugin, doesn't work with multiple dependencies"
 	echo "	gencert: Create keystore with SSL certificate in location where CAS looks by default"
+        echo "	command: Run the CAS command line shell and pass commands"
 }
 
 function clean() {
@@ -58,6 +59,10 @@ function gencert() {
 	keytool -exportcert -alias cas -storepass changeit -keystore /etc/cas/thekeystore -file /etc/cas/cas.cer
 }
 
+function command() {
+	package && java -jar target/cas/WEB-INF/lib/cas-server-support-shell-*.jar "$@"
+}
+
 if [ $# -eq 0 ]; then
     echo -e "No commands provided. Defaulting to [run]\n"
     run
@@ -89,6 +94,10 @@ case "$1" in
     ;;
 "gencert")
     gencert "$@"
+    ;;
+"command")
+    shift
+    command "$@"
     ;;
 *)
     help

--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,6 @@
             <type>war</type>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apereo.cas</groupId>
-            <artifactId>cas-server-support-shell</artifactId>
-            <version>${cas.version}</version>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </dependencies>
 
     <properties>
-        <cas.version>5.1.2</cas.version>
+        <cas.version>5.1.3</cas.version>
         <springboot.version>1.5.3.RELEASE</springboot.version>
         <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
         <app.server>-tomcat</app.server> 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
             <type>war</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-support-shell</artifactId>
+            <version>${cas.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
Adds a dependency for CAS Command Line Shell in the pom.xml file. Also adds the command "command" to build.sh as an option to invoke the shell with passed commands. 