### PR TITLE
Memcached deserialize

### DIFF
--- a/etc/cas/config/adminusers.properties
+++ b/etc/cas/config/adminusers.properties
@@ -1,0 +1,1 @@
+casuser=notused,ROLE_ADMIN

--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -49,3 +49,31 @@ cas.adminPagesSecurity.actuatorEndpointsEnabled=false
 
 cas.monitor.endpoints.enabled=true
 cas.monitor.endpoints.sensitive=false
+
+#########################################################
+## memcached ticket registry and related settings      ##
+#########################################################
+
+# Service Ticket Behavior.
+# cas.ticket.st.timeToKillInSeconds=10
+# Increase beyond normal reason so it won't time out while chasing through the debugger...
+cas.ticket.st.timeToKillInSeconds=28800
+
+# Proxy Ticket Behavior.
+# cas.ticket.pt.timeToKillInSeconds=10
+
+# Ticket Granting Tickets Behavior
+# Set to a negative value to never expire tickets
+# cas.ticket.tgt.maxTimeToLiveInSeconds=28800
+# cas.ticket.tgt.timeToKillInSeconds=7200
+
+cas.ticket.registry.memcached.servers=localhost:11211
+# cas.ticket.registry.memcached.locatorType=ARRAY_MOD
+# cas.ticket.registry.memcached.failureMode=Redistribute
+# cas.ticket.registry.memcached.hashAlgorithm=FNV1_64_HASH
+
+# cas.ticket.registry.memcached.crypto.signing.key=
+# cas.ticket.registry.memcached.crypto.signing.keySize=512
+# cas.ticket.registry.memcached.crypto.encryption.key=
+# cas.ticket.registry.memcached.crypto.encryption.keySize=16
+# cas.ticket.registry.memcached.crypto.alg=AES

--- a/etc/cas/config/cas.properties
+++ b/etc/cas/config/cas.properties
@@ -1,7 +1,51 @@
-cas.server.name: https://cas.example.org:8443
-cas.server.prefix: https://cas.example.org:8443/cas
+cas.server.name=https://localhost:8443
+cas.server.prefix=https://localhost:8443/cas
 
 cas.adminPagesSecurity.ip=127\.0\.0\.1
 
-logging.config: file:/etc/cas/config/log4j2.xml
-# cas.serviceRegistry.config.location: classpath:/services
+logging.config=file:/etc/cas/config/log4j2.xml
+
+# Where the Service Registry config files reside.
+# cas.serviceRegistry.config.location=classpath:/services
+cas.serviceRegistry.config.location=file:/etc/cas/config/services
+# Should CAS ALSO load service registry from $TEMP/cas/services?  Almost certainly no - just load from the
+# config location mentioned just above.
+cas.serviceRegistry.initFromJson=false
+
+cas.tgc.encryptionKey=n-mjo3eRBKS2D1bN-9LfyrAKs97qaVDS1qm_QnXjXSk
+cas.tgc.signingKey=pf7scXUAk-l6FmwWDVzOONH-Is8RU1OLIcGlTdTPJL_hYQvYz8zhwzOiLQQZE6I-sbJbiyNL7WP5jq9UkvxN7w
+
+cas.webflow.signing.key=73eYssgawTHjAjkH_4uaEw4wUdaXD3M1lsPoqk50lpdpr_tu0XtLKLZmS_0DIJcZ_dU99nuXX7EaG9OBHQN1JA
+cas.webflow.encryption.key=qblhBvdquHNqGjkw
+
+management.contextPath=/status
+management.security.enabled=false
+management.security.roles=ACTUATOR,ADMIN
+management.security.sessions=if_required
+
+endpoints.restart.enabled=false
+endpoints.shutdown.enabled=false
+endpoints.autoconfig.enabled=true
+endpoints.beans.enabled=true
+endpoints.bus.enabled=true
+endpoints.configprops.enabled=true
+endpoints.dump.enabled=true
+endpoints.env.enabled=true
+endpoints.health.enabled=true
+endpoints.features.enabled=true
+endpoints.info.enabled=true
+endpoints.loggers.enabled=true
+endpoints.logfile.enabled=true
+endpoints.trace.enabled=true
+endpoints.docs.enabled=false
+endpoints.heapdump.enabled=true
+
+cas.adminPagesSecurity.loginUrl=https://localhost:8443/cas/login
+cas.adminPagesSecurity.service=https://localhost:8443/cas/status/dashboard
+cas.adminPagesSecurity.users=file:/etc/cas/config/adminusers.properties
+cas.adminPagesSecurity.adminRoles[0]=ROLE_ADMIN
+
+cas.adminPagesSecurity.actuatorEndpointsEnabled=false
+
+cas.monitor.endpoints.enabled=true
+cas.monitor.endpoints.sensitive=false

--- a/etc/cas/config/log4j2.xml
+++ b/etc/cas/config/log4j2.xml
@@ -2,11 +2,11 @@
 <!-- Specify the refresh internal in seconds. -->
 <Configuration monitorInterval="5" packages="org.apereo.cas.logging">
     <Properties>
-        <!-- 
+        <!--
         Default log directory is the current directory but that can be overridden with -Dcas.log.dir=<logdir>
         Or you can change this property to a new default
         -->
-        <Property name="cas.log.dir" >.</Property>
+        <Property name="cas.log.dir" >/etc/cas/logs</Property>
         <!-- To see more CAS specific logging, adjust this property to info or debug or run server with -Dcas.log.leve=debug -->
         <Property name="cas.log.level" >warn</Property>
     </Properties>
@@ -107,8 +107,8 @@
         <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->
         <AsyncRoot level="warn">
             <AppenderRef ref="casFile"/>
-            <!-- 
-                 For deployment to an application server running as service, 
+            <!--
+                 For deployment to an application server running as service,
                  delete the casConsole appender below
             -->
             <AppenderRef ref="casConsole"/>

--- a/etc/cas/config/services/HTTPSandIMAPS-10000001.json
+++ b/etc/cas/config/services/HTTPSandIMAPS-10000001.json
@@ -1,0 +1,8 @@
+{
+  "@class" : "org.apereo.cas.services.RegexRegisteredService",
+  "serviceId" : "^(https|imaps)://.*",
+  "name" : "HTTPS and IMAPS",
+  "id" : 10000001,
+  "description" : "This service definition authorizes all application urls that support HTTPS and IMAPS protocols.",
+  "evaluationOrder" : 10000
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>cas-server-support-json-service-registry</artifactId>
             <version>${cas.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-support-memcached-ticket-registry</artifactId>
+            <version>${cas.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,18 @@
             <type>war</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-support-json-service-registry</artifactId>
+            <version>${cas.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>
         <cas.version>5.1.3</cas.version>
         <springboot.version>1.5.3.RELEASE</springboot.version>
         <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
-        <app.server>-tomcat</app.server> 
+        <app.server>-tomcat</app.server>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
DO NOT MERGE THIS PR!!!!

Contains the setup code to reproduce memcached deserialization exception.

See: https://groups.google.com/a/apereo.org/forum/?utm_medium=email&utm_source=footer#!topic/cas-user/NZ4hyt8SM_s

See cas issue: https://github.com/apereo/cas/issues/2921

Summary:
When running a fairly basic cas-overlay-template project with memcached, the attached exception is thrown ON THE SECOND READ OF THE ST Token.  (I.E. the first read, in MemCacheTicketRegistry method addTicket (the 'Sanity check' read) succeeds.  However, the subsequent call to method getTicket throws the exception.

Now - if you log out of CAS and log back in, without shutting down the CAS server, this next attempt (and subsequent) doesn't throw the exception.

To set up WITHOUT memcached (to show that without memcached things work fine) - just grab the FIRST commit, and build / run the CAS (build copy, then build run) server.

To setup WITH memcached, grab the second commit, and build / run the CAS server.  Remember to have a memcached server running...

From the CAS login page (https://localhost:8443/cas/login), press the 'Dashboard' link, then log in, and you'll see the CAS Dashboard.  Without memcached, anyways.  With memcached, it will error (CAS is unable to process this request: "500:Internal Server Error", with data "Error: cannot validate CAS ticket: ST-1-YFm3QHW7ObTQWdq5kbbd-DL-GB46TC2")