### PR TITLE
Additional Repos needed when adding CAS support dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         mavenLocal()
         jcenter()
+        maven { url "https://repo.spring.io/libs-milestone" }
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${project.springBootVersion}"
@@ -14,7 +15,8 @@ repositories {
     jcenter()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases/' }
-    maven { url "https://repo.spring.io/libs-milestone" }
+    maven { url "https://repo.spring.io/milestone/" }
+    maven { url "https://oss.jfrog.org/artifactory/oss-snapshot-local" }
 }
 
 apply from: "https://dl.bintray.com/scalding/generic/waroverlay.gradle"


### PR DESCRIPTION
Doh! Jumped the gun on the last pull request. 🤦 

After adding `cas-server-support-*` dependencies gradle again complains about missing packages due to RC and ML releases. 

I grabbed the repositories used by the CAS Server's `build.gradle` and narrowed it down to two necessary milestone and snapshot repositories. 

I was able to then build an overlay with LDAP, JDBC, U2F and other plugins without errors.

This also moves the spring `libs-milestone repo` up to the `buildscript` scope since after I did a `rm -rf .gradle` the gradle build failed. Moving it to the `buildscript` scope fixed the error.

Sorry about that!