### PR TITLE
fix copyCasConfiguration on windows

### DIFF
--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -25,9 +25,9 @@ def explodedDir="${buildDir}/cas"
 
 task copyCasConfiguration(type: Copy, group: "build", description: "Copy the CAS configuration from this project to /etc/cas/config") {
     from "etc/cas/config"
-    into "/etc/cas/config"
+    into new File('/etc/cas/config').absolutePath
     doFirst {
-        mkdir "/etc/cas/config"
+        new File('/etc/cas/config').mkdirs()
     }
 }
 


### PR DESCRIPTION
This task wasn't doing anything on windows. Changed according to https://stackoverflow.com/questions/33515064/gradle-accessing-files-outside-the-project which should work everywhere. 