### PR TITLE
fixing build for the `jib` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ tasks.findByName("jibDockerBuild")
     .dependsOn(copyWebAppIntoJib, copyConfigIntoJib)
     .finalizedBy(deleteWebAppFromJib)
 
+tasks.findByName("jib")
+    .dependsOn(copyWebAppIntoJib, copyConfigIntoJib)
+    .finalizedBy(deleteWebAppFromJib)
+    
 configurations.all {
     resolutionStrategy {
         cacheChangingModulesFor 0, "seconds"


### PR DESCRIPTION
When `jib` was used without a run of `jibDockerBuild` beforehand the war file was not copied into the docker image. The container failed to run in return.