### PR TITLE
Feature request: Allow copy resource by name with suffix

### DIFF
--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -225,6 +225,7 @@ task getResource(group: "build", description: "Fetch a CAS resource and move it 
 
         def results = fileTree(explodedResourcesDir).matching {
             include "**/${resourceName}.*"
+            include "**/${resourceName}"
         }
         if (results.isEmpty()) {
             println "No resources could be found matching ${resourceName}"


### PR DESCRIPTION
### Discussion related: 
https://groups.google.com/a/apereo.org/forum/#!topic/cas-user/0SrYraTDJ7M

### Changed Description
The `resourceName` property should allow more flexibility naming for resource name


- Before the PR, only this syntax for using getResouce is allowed:
> ./gradlew getResource -PresourceName=messages

- With this PR, the following syntax is also allowed (together with the above as well):
> ./gradlew getResource -PresourceName=messages.properties

See if the above PR make sense, thanks!