### PR TITLE
add missing gradle repository

### DIFF
--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -13,6 +13,7 @@ buildscript {
         mavenLocal()
         mavenCentral()
         jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
     dependencies {
         classpath "org.apache.ivy:ivy:${project.ivyVersion}"

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -13,8 +13,14 @@ buildscript {
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots"
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
     }
+    
     dependencies {
         classpath "org.apache.ivy:ivy:${project.ivyVersion}"
         classpath "org.apereo.cas:cas-server-core-api-configuration-model:${project.'cas.version'}"


### PR DESCRIPTION
The CAS snapshot repository is needed if building a overlay on a snapshot version if you haven't been building CAS locally.