### PR TITLE
Updated Jib dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     dependencies {
         classpath "de.undercouch:gradle-download-task:${project.gradleDownloadTaskVersion}"
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${project.springBootVersion}"
-        classpath "com.google.cloud.tools:jib-gradle-plugin:${project.jibVersion}"
+        classpath "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:${project.jibVersion}"
         classpath "io.freefair.gradle:maven-plugin:${project.gradleMavenPluginVersion}"
         classpath "io.freefair.gradle:lombok-plugin:${project.gradleLombokPluginVersion}"
     }


### PR DESCRIPTION
The last build doen't work. See Travis build: https://travis-ci.org/github/apereo/cas-overlay-template/jobs/697220902

Reading documentation about Jib:
https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin
Which refers to this other documentation:
https://plugins.gradle.org/plugin/com.google.cloud.tools.jib
The group referenced is different. 
