### PR TITLE
build.gradle: exclude tomcat-embed-el-9.0.52.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -543,7 +543,7 @@ bootWar {
 
 
             provided = false
-            excludes = ["WEB-INF/lib/servlet-api-2*.jar"]
+            excludes = ["WEB-INF/lib/servlet-api-2*.jar", "**/tomcat-embed-el-9.0.52.jar"]
             
             /*
             excludes = ["WEB-INF/lib/somejar-1.0*"]


### PR DESCRIPTION
When building cas to use with an external tomcat cotainer i.e.
`appServer=`.  The web application fails to start with the error:
```
   More than one fragment with the name [org_apache_jasper_el] was found.
   https://phabricator.wikimedia.org/P17581
```
This seems to be caused as the package WAR file contains multiple
versions of tomcat-embed-el:

```shell
  $ jar tvf ROOT.war  | grep tomcat
  255799 Wed Oct 20 16:00:26 UTC 2021 WEB-INF/lib/tomcat-embed-el-9.0.52.jar
  255866 Wed Oct 20 16:00:26 UTC 2021 WEB-INF/lib/tomcat-embed-el-9.0.54.jar
```

This PR updates build.gradle to exclude the 9.0.52 release