### PR TITLE
use "Sync" instead of "Copy" for unzipWAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ task createKeystore(group: "CAS", description: "Create CAS keystore") {
     }
 }
 
-task unzipWAR(type: Copy, group: "CAS", description: "Explodes the CAS web application archive") {
+task unzipWAR(type: Sync, group: "CAS", description: "Explodes the CAS web application archive") {
     dependsOn 'build'
     from zipTree("build/libs/cas.war")
     into "${buildDir}/app"


### PR DESCRIPTION
Important when you remove a jar dependency : remove it in exploded dir.

NB : "unzip" task is still using "Copy" mode since it *adds* files